### PR TITLE
Bump/tidy go.mod for go 1.17 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,17 @@
 module git.dev.pardot.com/pardot/pam_oidc
 
-go 1.16
+go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/pardot/oidc v0.0.0-20210414175742-5e4b86258770
 	gopkg.in/square/go-jose.v2 v2.5.1
+)
+
+require (
+	github.com/golang/protobuf v1.3.2 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 )


### PR DESCRIPTION
1. Change to `go 1.17`
2. `go mod tidy`

The `replace` changes are due to https://golang.org/doc/go1.17#go-command