### PR TITLE
rpm: put pam_oidc.so in the correct location

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -9,4 +9,4 @@ homepage: "https://salesforce.com"
 license: "BSD-3-Clause"
 contents:
   - src: pam_oidc.so
-    dst: /usr/lib64/pam_oidc.so
+    dst: /usr/lib64/security/pam_oidc.so


### PR DESCRIPTION
Corrects typo. These files should land in `/usr/lib64/security`