### PR TITLE
enforce ACR, allow specifying more than one

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Default: (no value)
 
 If specified, the required value of the `acr` claim in the token for authentication to pass.
 
+#### require\_acrs
+
+Default: (no value)
+
+If specified, a comma-separated list of acrs one of which must match the `acr` claim in the token for authentication to pass.
+
 #### http\_proxy
 
 Default: (no value)

--- a/config.go
+++ b/config.go
@@ -25,8 +25,9 @@ type config struct {
 	// A user must be a member of at least one of the groups in the list, if
 	// specified.
 	AuthorizedGroups []string
-	// RequireACR is the required ACR value that must be present in the claims.
-	RequireACR string
+	// RequireACRs is a list of required ACRs required for authentication to pass.
+	// one of the acr values must be present in the claims.
+	RequireACRs []string
 	// HTTPProxy is the HTTP proxy server used to connect to HTTP services.
 	HTTPProxy string
 }
@@ -52,7 +53,9 @@ func configFromArgs(args []string) (*config, error) {
 		case "authorized_groups":
 			c.AuthorizedGroups = strings.Split(parts[1], ",")
 		case "require_acr":
-			c.RequireACR = parts[1]
+			c.RequireACRs = []string{parts[1]}
+		case "require_acrs":
+			c.RequireACRs = strings.Split(parts[1], ",")
 		case "http_proxy":
 			c.HTTPProxy = parts[1]
 		default:

--- a/config_test.go
+++ b/config_test.go
@@ -36,10 +36,24 @@ func TestParseConfigFromArgs(t *testing.T) {
 				UserTemplate:     `{{.Email}}`,
 				GroupsClaimKey:   "roles",
 				AuthorizedGroups: []string{"foo", "bar", "baz"},
-				RequireACR:       "foo",
+				RequireACRs:      []string{"foo"},
 				HTTPProxy:        "http://example.com:8080",
 			},
 		},
+		{
+			name: "overriding defaults required_acrs",
+			args: []string{"issuer=https://example.com", "aud=example-aud", "user_template={{.Email}}", "groups_claim_key=roles", "authorized_groups=foo,bar,baz", "require_acrs=acr1,acr2,acr3", "http_proxy=http://example.com:8080"},
+			want: &config{
+				Issuer:           "https://example.com",
+				Aud:              "example-aud",
+				UserTemplate:     `{{.Email}}`,
+				GroupsClaimKey:   "roles",
+				AuthorizedGroups: []string{"foo", "bar", "baz"},
+				RequireACRs:      []string{"acr1", "acr2", "acr3"},
+				HTTPProxy:        "http://example.com:8080",
+			},
+		},
+
 		{
 			name:    "invalid option",
 			args:    []string{"issuer=https://example.com", "invalid=foo"},

--- a/pam_oidc.go
+++ b/pam_oidc.go
@@ -87,6 +87,7 @@ func pam_sm_authenticate_go(pamh *C.pam_handle_t, flags C.int, argc C.int, argv 
 	auth.UserTemplate = cfg.UserTemplate
 	auth.GroupsClaimKey = cfg.GroupsClaimKey
 	auth.AuthorizedGroups = cfg.AuthorizedGroups
+	auth.RequireACRs = cfg.RequireACRs
 
 	if err := auth.Authenticate(ctx, user, token); err != nil {
 		pamSyslog(pamh, syslog.LOG_WARNING, "failed to authenticate: %v", err)


### PR DESCRIPTION
### Why

1. We found a bug where required_acr isn't enforced
2. We'd like to be able to slow-roll an acr change, allowing more than one allows support of multiple acr's temporarily during a switch


### How

1. Fix a bug where config values for acr weren't copied to the authenticator: https://github.com/salesforce/pam_oidc/compare/fix_required_acr?expand=1#diff-4fe6c496c889975889f5d4c648d20d5e207c33f76a51fc43885c5b3bc7d4235fR90
2. Allow for specifying `required_acrs` validate that the acr is present in a list