### PR TITLE
generate nfpm at runtime appending the version name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ $(MODULE).so: .
 	go build -buildmode=c-shared -o $@
 
 rpm: $(MODULE).so
+	env VERSIONED_OIDC_LIB="pam_oidc.so.$(shell hack/package_version.sh)" envsubst '$${VERSIONED_OIDC_LIB}' < src_nfpm.yaml > nfpm.yaml
 	env VERSION=$(shell hack/package_version.sh) nfpm package --packager rpm
 
 test:

--- a/src_nfpm.yaml
+++ b/src_nfpm.yaml
@@ -1,0 +1,12 @@
+name: "pam_oidc"
+arch: "amd64"
+platform: "linux"
+version: "${VERSION}"
+description: |
+  pam_oidc authenticates users with an OpenID Connect (OIDC) token.
+vendor: "Salesforce"
+homepage: "https://salesforce.com"
+license: "BSD-3-Clause"
+contents:
+  - src: pam_oidc.so
+    dst: /usr/lib64/security/${VERSIONED_OIDC_LIB}


### PR DESCRIPTION
### Problem

Updating from 0.0.3 to 0.0.4 caused issues. mysql (pam?) doesn't like reloading pam modules dynamically; and won't pick up the updated lib in `/usr/lib64/security`

### Solution

Have the rpm output the library with version number appended, then when updating this we can update our references in `/etc/pam.d/mysql` to include the version for example:

```
#%PAM-1.0
auth required pam_oidc.so.0.0.4 issuer=...
auth required pam_warn.so
```

### Still remaining

If this is ok i'll push up the tag, validate the action behaves properly, and merge